### PR TITLE
Add tests for rest clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
 
     <!-- plugin versions -->
     <spotless-maven-plugin.version>2.44.2</spotless-maven-plugin.version>
+    <wiremock.version>3.10.0</wiremock.version>
   </properties>
 
   <dependencies>
@@ -66,6 +67,12 @@
       <artifactId>mapstruct</artifactId>
       <version>${org.mapstruct.version}</version>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <version>${wiremock.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/holly/jukebox/service/coverartarchive/impl/CoverArtArchiveRestClientImpl.java
+++ b/src/main/java/holly/jukebox/service/coverartarchive/impl/CoverArtArchiveRestClientImpl.java
@@ -3,11 +3,15 @@ package holly.jukebox.service.coverartarchive.impl;
 import holly.jukebox.service.coverartarchive.CoverArtArchiveCache;
 import holly.jukebox.service.coverartarchive.CoverArtArchiveRestClient;
 import holly.jukebox.service.coverartarchive.config.CoverArtArchiveConfig;
+import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -36,12 +40,26 @@ class CoverArtArchiveRestClientImpl implements CoverArtArchiveRestClient {
 
     log.info("Outgoing call to Cover art archive for front cover with id '{}'", id);
     final ResponseEntity<String> response =
-        client.get().uri("/release-group/{id}", Map.of("id", id)).retrieve().toEntity(String.class);
+        client
+            .get()
+            .uri("/release-group/{id}", Map.of("id", id))
+            .retrieve()
+            .onStatus(HttpStatusCode::is4xxClientError, this::onlyLogResponseError)
+            .onStatus(HttpStatusCode::is5xxServerError, this::onlyLogResponseError)
+            .toEntity(String.class);
 
     if (response.getStatusCode().is2xxSuccessful()) {
       coverArtArchiveCache.storeFrontCoverForIdResponse(id, response.getBody());
     }
 
     return response;
+  }
+
+  private void onlyLogResponseError(HttpRequest request, ClientHttpResponse response)
+      throws IOException {
+    log.warn(
+        "MusicBrainz responded with '{}': {}",
+        response.getStatusCode().value(),
+        new String(response.getBody().readAllBytes()));
   }
 }

--- a/src/main/java/holly/jukebox/service/musicbrainz/impl/MusicBrainzRestClientImpl.java
+++ b/src/main/java/holly/jukebox/service/musicbrainz/impl/MusicBrainzRestClientImpl.java
@@ -3,11 +3,15 @@ package holly.jukebox.service.musicbrainz.impl;
 import holly.jukebox.service.musicbrainz.MusicBrainzCache;
 import holly.jukebox.service.musicbrainz.MusicBrainzRestClient;
 import holly.jukebox.service.musicbrainz.config.MusicBrainzConfig;
+import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -45,6 +49,8 @@ class MusicBrainzRestClientImpl implements MusicBrainzRestClient {
             .get()
             .uri("/artist/?query=artist:{name}&fmt=json&limit=1", Map.of("name", name))
             .retrieve()
+            .onStatus(HttpStatusCode::is4xxClientError, this::onlyLogResponseError)
+            .onStatus(HttpStatusCode::is5xxServerError, this::onlyLogResponseError)
             .toEntity(String.class);
 
     if (response.getStatusCode().is2xxSuccessful()) {
@@ -52,6 +58,14 @@ class MusicBrainzRestClientImpl implements MusicBrainzRestClient {
     }
 
     return response;
+  }
+
+  private void onlyLogResponseError(HttpRequest request, ClientHttpResponse response)
+      throws IOException {
+    log.warn(
+        "MusicBrainz responded with '{}': {}",
+        response.getStatusCode().value(),
+        new String(response.getBody().readAllBytes()));
   }
 
   @Override
@@ -70,6 +84,8 @@ class MusicBrainzRestClientImpl implements MusicBrainzRestClient {
             .get()
             .uri("/artist/{mbid}?&fmt=json&inc=url-rels+release-groups", Map.of("mbid", mbid))
             .retrieve()
+            .onStatus(HttpStatusCode::is4xxClientError, this::onlyLogResponseError)
+            .onStatus(HttpStatusCode::is5xxServerError, this::onlyLogResponseError)
             .toEntity(String.class);
 
     if (response.getStatusCode().is2xxSuccessful()) {

--- a/src/main/java/holly/jukebox/service/wiki/impl/WikidataRestClientImpl.java
+++ b/src/main/java/holly/jukebox/service/wiki/impl/WikidataRestClientImpl.java
@@ -3,11 +3,15 @@ package holly.jukebox.service.wiki.impl;
 import holly.jukebox.service.wiki.WikiCache;
 import holly.jukebox.service.wiki.WikidataRestClient;
 import holly.jukebox.service.wiki.config.WikiConfig;
+import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -43,6 +47,8 @@ class WikidataRestClientImpl implements WikidataRestClient {
                 "?action=wbgetentities&ids={id}&format=json&props=sitelinks",
                 Map.of("id", wikidataId))
             .retrieve()
+            .onStatus(HttpStatusCode::is4xxClientError, this::onlyLogResponseError)
+            .onStatus(HttpStatusCode::is5xxServerError, this::onlyLogResponseError)
             .toEntity(String.class);
 
     if (response.getStatusCode().is2xxSuccessful()) {
@@ -50,5 +56,13 @@ class WikidataRestClientImpl implements WikidataRestClient {
     }
 
     return response;
+  }
+
+  private void onlyLogResponseError(HttpRequest request, ClientHttpResponse response)
+      throws IOException {
+    log.warn(
+        "MusicBrainz responded with '{}': {}",
+        response.getStatusCode().value(),
+        new String(response.getBody().readAllBytes()));
   }
 }

--- a/src/test/java/holly/jukebox/TestUtils.java
+++ b/src/test/java/holly/jukebox/TestUtils.java
@@ -1,0 +1,26 @@
+package holly.jukebox;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class TestUtils {
+
+  public static String musicBrainzResource(final String resourceName) throws IOException {
+    return readFile("src/test/resources/music-brainz/" + resourceName);
+  }
+
+  public static String wikiResource(final String resourceName) throws IOException {
+    return readFile("src/test/resources/wiki/" + resourceName);
+  }
+
+  public static String coverArtArchiveFile(final String resourceName) throws IOException {
+    return readFile("src/test/resources/cover-art-archive/" + resourceName);
+  }
+
+  public static String readFile(final String resourceName) throws IOException {
+    Path path = Paths.get(resourceName);
+    return Files.readString(path);
+  }
+}

--- a/src/test/java/holly/jukebox/service/coverartarchive/impl/CoverArtArchiveRestClientImplTest.java
+++ b/src/test/java/holly/jukebox/service/coverartarchive/impl/CoverArtArchiveRestClientImplTest.java
@@ -1,0 +1,94 @@
+package holly.jukebox.service.coverartarchive.impl;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import holly.jukebox.service.coverartarchive.CoverArtArchiveCache;
+import holly.jukebox.service.coverartarchive.CoverArtArchiveRestClient;
+import holly.jukebox.service.coverartarchive.config.CoverArtArchiveConfig;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.client.RestClient;
+
+@WireMockTest(httpPort = 6060)
+@ExtendWith(SpringExtension.class)
+@EnableConfigurationProperties(value = CoverArtArchiveConfig.class)
+@TestPropertySource(properties = {"cover-art-archive.base-url=http://localhost:6060"})
+class CoverArtArchiveRestClientImplTest {
+
+  @Autowired CoverArtArchiveConfig coverArtArchiveConfig;
+
+  CoverArtArchiveRestClient coverArtArchiveRestClient;
+
+  @BeforeEach
+  void setup() {
+    coverArtArchiveRestClient =
+        new CoverArtArchiveRestClientImpl(
+            RestClient.builder(), new NoOpCache(), coverArtArchiveConfig);
+  }
+
+  @Test
+  void findCoversForId() {
+    // Prepare
+    String response =
+        """
+        {
+          "images": [
+            {
+              "approved": true,
+              "back": false,
+              "comment": "",
+              "edit": 76926598,
+              "front": true,
+              "id": 28467016197,
+              "image": "http://coverartarchive.org/release/81ae60d4-5b75-38df-903a-db2cfa51c2c6/28467016197.jpg",
+              "thumbnails": {
+                "1200": "http://coverartarchive.org/release/81ae60d4-5b75-38df-903a-db2cfa51c2c6/28467016197-1200.jpg",
+                "250": "http://coverartarchive.org/release/81ae60d4-5b75-38df-903a-db2cfa51c2c6/28467016197-250.jpg",
+                "500": "http://coverartarchive.org/release/81ae60d4-5b75-38df-903a-db2cfa51c2c6/28467016197-500.jpg",
+                "large": "http://coverartarchive.org/release/81ae60d4-5b75-38df-903a-db2cfa51c2c6/28467016197-500.jpg",
+                "small": "http://coverartarchive.org/release/81ae60d4-5b75-38df-903a-db2cfa51c2c6/28467016197-250.jpg"
+              },
+              "types": [
+                "Front"
+              ]
+            },
+          ],
+        }
+        """;
+
+    // Expect
+    WireMock.stubFor(
+        get(urlPathTemplate("/release-group/{id}"))
+            .withPathParam("id", equalTo("album-id"))
+            .willReturn(okJson(response)));
+
+    // Execute
+    ResponseEntity<String> artistByName = coverArtArchiveRestClient.findCoversForId("album-id");
+
+    // Assert
+    assertThat(artistByName.getStatusCode().is2xxSuccessful()).isTrue();
+    assertThat(artistByName.getBody()).isEqualTo(response);
+  }
+
+  static class NoOpCache implements CoverArtArchiveCache {
+    @Override
+    public Optional<String> findFrontCoverForId(String id) {
+      return Optional.empty();
+    }
+
+    @Override
+    public void storeFrontCoverForIdResponse(String id, String response) {}
+  }
+}

--- a/src/test/java/holly/jukebox/service/coverartarchive/impl/CoverArtArchiveServiceImplTest.java
+++ b/src/test/java/holly/jukebox/service/coverartarchive/impl/CoverArtArchiveServiceImplTest.java
@@ -3,11 +3,8 @@ package holly.jukebox.service.coverartarchive.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import holly.jukebox.TestUtils;
 import holly.jukebox.service.coverartarchive.CoverArtArchiveRestClient;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -30,7 +27,7 @@ class CoverArtArchiveServiceImplTest {
   @Test
   void findCoversForId() throws Exception {
     // Prepare
-    String coversResult = readFile("covers_result.json");
+    String coversResult = TestUtils.coverArtArchiveFile("covers_result.json");
 
     // Expect
     when(coverArtArchiveRestClient.findCoversForId("id"))
@@ -62,10 +59,5 @@ class CoverArtArchiveServiceImplTest {
 
     // Assert
     assertThat(frontCover).isEmpty();
-  }
-
-  private static String readFile(final String resourceName) throws IOException {
-    Path path = Paths.get("src/test/resources/cover-art-archive/" + resourceName);
-    return Files.readString(path);
   }
 }

--- a/src/test/java/holly/jukebox/service/musicbrainz/impl/MusicBrainzRestClientImplTest.java
+++ b/src/test/java/holly/jukebox/service/musicbrainz/impl/MusicBrainzRestClientImplTest.java
@@ -1,0 +1,113 @@
+package holly.jukebox.service.musicbrainz.impl;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import holly.jukebox.service.musicbrainz.MusicBrainzCache;
+import holly.jukebox.service.musicbrainz.MusicBrainzRestClient;
+import holly.jukebox.service.musicbrainz.config.MusicBrainzConfig;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.client.RestClient;
+
+@WireMockTest(httpPort = 6060)
+@ExtendWith(SpringExtension.class)
+@EnableConfigurationProperties(value = MusicBrainzConfig.class)
+@TestPropertySource(
+    properties = {
+      "music-brainz.base-url=http://localhost:6060",
+      "music-brainz.user-agent=test-agent"
+    })
+class MusicBrainzRestClientImplTest {
+
+  @Autowired MusicBrainzConfig musicBrainzConfig;
+
+  MusicBrainzRestClient musicBrainzRestClient;
+
+  @BeforeEach
+  void setup() {
+    musicBrainzRestClient =
+        new MusicBrainzRestClientImpl(RestClient.builder(), new NoOpCache(), musicBrainzConfig);
+  }
+
+  @Test
+  void findArtistByName() {
+    // Prepare
+    String response =
+        """
+        {
+          "artist": "DJ Nicke Lill-Troll",
+          "status": "Up-and-coming",
+          "id": "abc123"
+        }
+        """;
+
+    // Expect
+    WireMock.stubFor(
+        get(urlPathEqualTo("/artist/"))
+            .withQueryParam("query", equalTo("artist:DJ Nicke Lill-Troll"))
+            .willReturn(okJson(response)));
+
+    // Execute
+    ResponseEntity<String> artistByName =
+        musicBrainzRestClient.findArtistByName("DJ Nicke Lill-Troll");
+
+    // Assert
+    assertThat(artistByName.getStatusCode().is2xxSuccessful()).isTrue();
+    assertThat(artistByName.getBody()).isEqualTo(response);
+  }
+
+  @Test
+  void fetchArtistInformationById() {
+    // Prepare
+    String response =
+        """
+        {
+          "artist": "Dj Nicke Lill-Troll",
+          "status": "Up-and-coming",
+          "id": "abc123",
+        }
+        """;
+
+    // Expect
+    WireMock.stubFor(
+        get(urlPathTemplate("/artist/{mbid}"))
+            .withPathParam("mbid", equalTo("abc123"))
+            .willReturn(okJson(response)));
+
+    // Execute
+    ResponseEntity<String> artistByName =
+        musicBrainzRestClient.fetchArtistInformationById("abc123");
+
+    // Assert
+    assertThat(artistByName.getStatusCode().is2xxSuccessful()).isTrue();
+    assertThat(artistByName.getBody()).isEqualTo(response);
+  }
+
+  static class NoOpCache implements MusicBrainzCache {
+    @Override
+    public Optional<String> findArtistByName(String artistName) {
+      return Optional.empty();
+    }
+
+    @Override
+    public void storeArtistByNameResponse(String artistName, String response) {}
+
+    @Override
+    public Optional<String> fetchArtistInformationById(String mbid) {
+      return Optional.empty();
+    }
+
+    @Override
+    public void storeArtistInformationByIdResponse(String mbid, String response) {}
+  }
+}

--- a/src/test/java/holly/jukebox/service/musicbrainz/impl/MusicBrainzServiceImplTest.java
+++ b/src/test/java/holly/jukebox/service/musicbrainz/impl/MusicBrainzServiceImplTest.java
@@ -3,13 +3,10 @@ package holly.jukebox.service.musicbrainz.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import holly.jukebox.TestUtils;
 import holly.jukebox.service.musicbrainz.MusicBrainzRestClient;
 import holly.jukebox.service.musicbrainz.model.AlbumResult;
 import holly.jukebox.service.musicbrainz.model.ArtistResult;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -32,7 +29,7 @@ class MusicBrainzServiceImplTest {
   @Test
   void findIdByArtistName() throws Exception {
     // Prepare
-    String searchResult = readFile("artist_search_result.json");
+    String searchResult = TestUtils.musicBrainzResource("artist_search_result.json");
 
     // Expect
     when(musicBrainzRestClient.findArtistByName("avicii"))
@@ -91,7 +88,7 @@ class MusicBrainzServiceImplTest {
   @Test
   void fetchArtistInformationById() throws Exception {
     // Prepare
-    String artistResultResponse = readFile("artist_id_result.json");
+    String artistResultResponse = TestUtils.musicBrainzResource("artist_id_result.json");
 
     // Expect
     when(musicBrainzRestClient.fetchArtistInformationById("c85cfd6b-b1e9-4a50-bd55-eb725f04f7d5"))
@@ -190,10 +187,5 @@ class MusicBrainzServiceImplTest {
 
     // Assert
     assertThat(wikidataId).isEqualTo(expectedId);
-  }
-
-  private static String readFile(final String resourceName) throws IOException {
-    Path path = Paths.get("src/test/resources/music-brainz/" + resourceName);
-    return Files.readString(path);
   }
 }

--- a/src/test/java/holly/jukebox/service/wiki/impl/NoOpCacheWikiCache.java
+++ b/src/test/java/holly/jukebox/service/wiki/impl/NoOpCacheWikiCache.java
@@ -1,0 +1,22 @@
+package holly.jukebox.service.wiki.impl;
+
+import holly.jukebox.service.wiki.WikiCache;
+import java.util.Optional;
+
+class NoOpCacheWikiCache implements WikiCache {
+  @Override
+  public Optional<String> fetchSitelinksForId(String wikidataId) {
+    return Optional.empty();
+  }
+
+  @Override
+  public void storeSitelinksForIdResponse(String wikidataId, String response) {}
+
+  @Override
+  public Optional<String> fetchDescriptionForTitle(String title) {
+    return Optional.empty();
+  }
+
+  @Override
+  public void storeDescriptionForTitleResponse(String title, String response) {}
+}

--- a/src/test/java/holly/jukebox/service/wiki/impl/WikiServiceImplTest.java
+++ b/src/test/java/holly/jukebox/service/wiki/impl/WikiServiceImplTest.java
@@ -3,12 +3,9 @@ package holly.jukebox.service.wiki.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import holly.jukebox.TestUtils;
 import holly.jukebox.service.wiki.WikidataRestClient;
 import holly.jukebox.service.wiki.WikipediaRestClient;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -33,7 +30,7 @@ class WikiServiceImplTest {
   @Test
   void fetchSitelinksForId() throws Exception {
     // Prepare
-    String searchResult = readFile("site_links_result.json");
+    String searchResult = TestUtils.wikiResource("site_links_result.json");
 
     // Expect
     when(wikidataRestClient.fetchSitelinksForId("Q15862"))
@@ -69,7 +66,7 @@ class WikiServiceImplTest {
   @Test
   void fetchDescriptionForTitle() throws Exception {
     // Prepare
-    String searchResult = readFile("title_result.json");
+    String searchResult = TestUtils.wikiResource("title_result.json");
 
     // Expect
     when(wikipediaRestClient.fetchDescriptionForTitle("title"))
@@ -95,10 +92,5 @@ class WikiServiceImplTest {
 
     // Assert
     assertThat(description).isEmpty();
-  }
-
-  private static String readFile(final String resourceName) throws IOException {
-    Path path = Paths.get("src/test/resources/wiki/" + resourceName);
-    return Files.readString(path);
   }
 }

--- a/src/test/java/holly/jukebox/service/wiki/impl/WikidataRestClientImplTest.java
+++ b/src/test/java/holly/jukebox/service/wiki/impl/WikidataRestClientImplTest.java
@@ -1,0 +1,72 @@
+package holly.jukebox.service.wiki.impl;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import holly.jukebox.service.wiki.WikidataRestClient;
+import holly.jukebox.service.wiki.config.WikiConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.client.RestClient;
+
+@WireMockTest(httpPort = 6060)
+@ExtendWith(SpringExtension.class)
+@EnableConfigurationProperties(value = WikiConfig.class)
+@TestPropertySource(properties = {"wiki.wikidata.base-url=http://localhost:6060"})
+class WikidataRestClientImplTest {
+
+  @Autowired WikiConfig wikiConfig;
+
+  WikidataRestClient wikidataRestClient;
+
+  @BeforeEach
+  void setup() {
+    wikidataRestClient =
+        new WikidataRestClientImpl(RestClient.builder(), new NoOpCacheWikiCache(), wikiConfig);
+  }
+
+  @Test
+  void fetchSitelinksForId() {
+    // Prepare
+    String response =
+        """
+        {
+          "entities": {
+            "Q15862": {
+              "type": "item",
+              "id": "Q15862",
+              "sitelinks": {
+                "abwiki": {
+                  "site": "abwiki",
+                  "title": "Queen",
+                  "badges": []
+                }
+              }
+            }
+          }
+        }
+        """;
+
+    // Expect
+    WireMock.stubFor(
+        get(urlPathEqualTo("/"))
+            .withQueryParam("ids", equalTo("Q15862"))
+            .willReturn(okJson(response)));
+
+    // Execute
+    ResponseEntity<String> artistByName = wikidataRestClient.fetchSitelinksForId("Q15862");
+
+    // Assert
+    assertThat(artistByName.getStatusCode().is2xxSuccessful()).isTrue();
+    assertThat(artistByName.getBody()).isEqualTo(response);
+  }
+}

--- a/src/test/java/holly/jukebox/service/wiki/impl/WikipediaRestClientImplTest.java
+++ b/src/test/java/holly/jukebox/service/wiki/impl/WikipediaRestClientImplTest.java
@@ -1,0 +1,76 @@
+package holly.jukebox.service.wiki.impl;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import holly.jukebox.service.wiki.WikipediaRestClient;
+import holly.jukebox.service.wiki.config.WikiConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.client.RestClient;
+
+@WireMockTest(httpPort = 6060)
+@ExtendWith(SpringExtension.class)
+@EnableConfigurationProperties(value = WikiConfig.class)
+@TestPropertySource(properties = {"wiki.wikipedia.base-url=http://localhost:6060"})
+class WikipediaRestClientImplTest {
+
+  @Autowired WikiConfig wikiConfig;
+
+  WikipediaRestClient wikipediaRestClient;
+
+  @BeforeEach
+  void setup() {
+    wikipediaRestClient =
+        new WikipediaRestClientImpl(RestClient.builder(), new NoOpCacheWikiCache(), wikiConfig);
+  }
+
+  @Test
+  void fetchDescriptionForTitle() {
+    // Prepare
+    String response =
+        """
+        {
+          "batchcomplete": "",
+          "warnings": {
+            "extracts": {
+              "*": "Warning!"
+            }
+          },
+          "query": {
+            "pages": {
+              "42010": {
+                "pageid": 42010,
+                "ns": 0,
+                "title": "Queen (band)",
+                "extract": "Cool band"
+              }
+            }
+          }
+        }
+        """;
+
+    // Expect
+    WireMock.stubFor(
+        get(urlPathEqualTo("/"))
+            .withQueryParam("titles", equalTo("Queen (band)"))
+            .willReturn(okJson(response)));
+
+    // Execute
+    ResponseEntity<String> artistByName =
+        wikipediaRestClient.fetchDescriptionForTitle("Queen (band)");
+
+    // Assert
+    assertThat(artistByName.getStatusCode().is2xxSuccessful()).isTrue();
+    assertThat(artistByName.getBody()).isEqualTo(response);
+  }
+}


### PR DESCRIPTION
Revealed that onStatus handling was needed to prevent default exceptions being thrown.